### PR TITLE
Update version of simple_kernel requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 simple_kernel
 =============
 
-A small, simple kernel example for IPython 1.1
+A small, simple kernel example for Jupyter, specification version: 5.0
+
+## Run
 
 Download and run:
 
@@ -11,7 +13,74 @@ Download and run:
 
 `ipython qtconsole --KernelManager.kernel_cmd="['python', 'simple_kernel.py', '{connection_file}']"`
 
-Current status:
+### Alternative way
+
+Install Jupyter
+
+```Bash
+$ git clone https://github.com/jupyter/notebook.git
+$ cd notebook
+$ mkvirtualenv jupyter-env
+$ workon jupyter-env
+(jupyter-env) $ pip install --pre -e .
+(jupyter-env) $ pip install jupyter-console
+```
+
+Download project to the different directory, install (prepare kernel.json file with `install_script.sh` script) and run:
+
+```Bash
+(jupyter-env) $ git clone https://github.com/dsblank/simple_kernel.git
+(jupyter-env) $ ./install_script.sh
+(jupyter-env) $ jupyter console --kernel simple_kernel
+```
+
+### Testing kernel
+
+You can test your project using [jupyter_kernel_test](https://github.com/jupyter/jupyter_kernel_test) project.
+
+Clone this project:
+
+```Bash
+(jupyter-env) $ git clone https://github.com/jupyter/jupyter_kernel_test
+(jupyter_env) $ cd jupyter_kernel_test
+```
+
+Modify `test_ipython.py` file to look like this:
+
+```Python
+import unittest
+import jupyter_kernel_test as jkt
+
+class IRkernelTests(jkt.KernelTests):
+    kernel_name = "simple_kernel"
+    language_name = "simple_kernel"
+
+    code_hello_world = "print('hello, world')"
+
+if __name__ == '__main__':
+    unittest.main()
+```
+
+and run this project with following command:
+
+```Bash
+(jupyter-env) $ python test_ipython.py
+```
+
+Output should be similar to this:
+
+```Bash
+### some debug information
+----------------------------------------------------------------------
+Ran 5 tests in 1.034s
+
+OK (skipped=3)
+```
+
+Current status
+----------
+
+Features:
 
 * shell, heartbeat, and iopub channels working
 * signatures are correct
@@ -36,7 +105,7 @@ Other Kernel Examples
 
 Here is a list of all of the standalone kernels (backends) that I know about. I don't think I got a single one to run, however.
 
-* https://github.com/gibiansky/IHaskell - Written in Haskell 
+* https://github.com/gibiansky/IHaskell - Written in Haskell
 * https://github.com/takluyver/igo - Written in Go
  * fails to build, needs Go 1.2?
 * https://github.com/mattpap/IScala - Written in Scala
@@ -46,7 +115,7 @@ Here is a list of all of the standalone kernels (backends) that I know about. I 
  *  needs "sudo ln -s /usr/lib/x86_64-linux-gnu/libjansson.so.4 /usr/lib/libjansson.so"
  *  needs "sudo apt-get install uuid-dev"
  *  echo fails, needs M_UUID defined
-* http://nbviewer.ipython.org/gist/Carreau/4279371/node-kernel.ipynb - Written in JavaScript 
+* http://nbviewer.ipython.org/gist/Carreau/4279371/node-kernel.ipynb - Written in JavaScript
  * needs "sudo apt-get install libzmq-dev"
  * ImportError: The IPython Notebook requires tornado >= 3.1.0, but you have 2.4.1
  * After upgrading "sudo pip install tornado": ImportError: No module named zmq.subprocesskernel

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mkdir -p ~/.ipython/kernels/simple_kernel/
+START_SCRIPT_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)/simple_kernel.py
+PYTHON_PATH=$(which python)
+CONTENT='{
+   "argv": ["'${PYTHON_PATH}'", "'${START_SCRIPT_PATH}'", "{connection_file}"],
+                "display_name": "simple_kernel",
+                "language": "simple_kernel"
+}'
+echo $CONTENT > ~/.ipython/kernels/simple_kernel/kernel.json


### PR DESCRIPTION
Hi,

I wonder if you would like to merge those changes. In the newest version of IPython (Jupyter) there was some in protocol of communication.

Also, I made an install_script.sh which makes ~/.ipython/kernels/simple_kernel/kernel.json file with proper values. Now you are able to run kernel like this:
```Bash
jupyter console --kernel simple_kernel
```
Please remember to install https://github.com/jupyter/jupyter_console in your virtual environment.

Also you can try to test your project with this: https://github.com/jupyter/jupyter_kernel_test. If you clone this repo and modify test_ipython.py file to look like this:
```Python
import unittest
import jupyter_kernel_test as jkt

class IRkernelTests(jkt.KernelTests):
    kernel_name = "simple_kernel"
    language_name = "simple_kernel"

    code_hello_world = "print('hello, world')"

if __name__ == '__main__':
    unittest.main()
```

And then run it with this:
```Bash
python test_ipython.py
```

The output should look like this:
```Bash
### some debug information
----------------------------------------------------------------------
Ran 5 tests in 1.034s

OK (skipped=3)
```

I can modify README.md file to include those information if you like.