### PR TITLE
Fix hanging on kernel ready in jupyterlab

### DIFF
--- a/simple_kernel.py
+++ b/simple_kernel.py
@@ -230,6 +230,10 @@ def shell_handler(msg):
             "banner": ""
         }
         send(shell_stream, 'kernel_info_reply', content, parent_header=msg['header'], identities=identities)
+        content = {
+            'execution_state': "idle",
+        }
+        send(iopub_stream, 'status', content, parent_header=msg['header'])
     elif msg['header']["msg_type"] == "history_request":
         dprint(1, "unhandled history request")
     else:


### PR DESCRIPTION
This adds an idle call, which is what jupyterlab needs to see before it
decides that a kernel is ready.  This differs from the notebook and is
documented here: https://github.com/jupyterlab/jupyterlab/issues/470